### PR TITLE
Add Reverting Migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # Caravel
 
-Caravel manages PostgreSQL migration files smartly and efficiently.
+Maintaining migrations for databases shouldn’t be complicated. Often, depending whether framework or language you use, you should learn a whole new system and technologies to get your migrations up and running. But why woud like to recreate an other query language, when SQL is already there?
+
+Caravel made choice to stick with simple, bare SQL, and tries to manage PostgreSQL migration files smartly and efficiently.
+
+Caravel uses both your filesystem (and your versionning system) and writes directly into your database to make sure its state remains consistent between your migrations and the database schema.
+
+Caravel does not have any prerequisite except of a PostgreSQL installation up and running. Add it to your `package.json`, and start using it right away.
+
+#### In case you don’t really know what migrations is.
+
+In most of the NoSQL world, you really don’t need migrations. Because your data defines your schema, you just write code writing into your database, and everything is working right away.
+
+In the SQL world, we need to establish the schema before adding any new data into the database, and we need to ensure the database state remains consistent during time. We have a system called "migrations".  
+A migration is simply a file, telling the database how to modify the global schema. Because your database is such an important place, and because we need to be able to share code between teams members, we need a way to ensure that everyone can get the same state than the others easily.  
+Every migration is made of a database modification, and is timestamped, in order to trace easily every modification to the database. When you need to enter new data into the database, create a new migration, migrate it, and you’re good to go!
+
+# Getting Started
 
 ## Installation
+
+Add the tool to your `package.json`. You’ll be able to use caravel by using `yarn caravel` (or `npm run caravel`). You don’t need to rely on global package.
 
 ```bash
 # Yarn users
@@ -16,47 +34,159 @@ npm install --save @wolfox/caravel
 
 ## Requirements
 
-To be able to use caravel you need **database** and a **migration folder** containing **migration files** formatted as:
+To be able to use caravel you need a [PostgreSQL database](https://www.postgresql.org/) and a `migration` folder containing up and down migration files.
 
-`versionNumber-migrationName.sql`
+### PostgreSQL
 
-**Example:**
+Installing PostgreSQL can be as easy as `brew install postgresql` or `apt-get install postgresql`, depending on your operating system. You can of course install Postgres from source, but getting it from homebrew or from your system package manager is simpler and ensure you always use a correct and up to date Postgres version.  
+However, you should probably use Docker to get Postgres running. [There is plenty of](https://hub.docker.com/_/postgres) [documentation about it.](https://hackernoon.com/dont-install-postgres-docker-pull-postgres-bee20e200198) You should find what you need easily.
 
-`001-user-table.sql`
-
-*You know the drill.*
-
-## Environment setup
-
- Caravel requires the user to setup two environment variables in your project's `.env` file:
-
-- `DATABASE_URL` is used to connect to the database you wish to update.
-- `MIGRATION_FOLDER_NAME` is used to locate your migration folder and thus to search for migrations to apply.
-
-**Example:**
-
-Your `.env` file should look something like this:
-
-```dotenv
-DATABASE_URL = 'postgres://username:password@localhost:5432/database_name'
-MIGRATION_FOLDER_NAME = './your_migration_folder'
-```
-
-## How it works
-
-Caravel will look through your migration folder for migrations that haven't already been applied to your database. In order to do this, it will compare your migration version numbers with the ones stored in the `caravel-migrations` table, and run those that need to be, updating both your project's database and the migrations table.
-*Caravel will create the `caravel_migrations` table if it doesn't already exist.*
-
-## Usage
-
-To execute your migrations with caravel, run:
+### Migration files
 
 ```bash
-caravel migrate # caravel -m is equivalent
+# Migrations files should be labelled like this.
+timestamp-migration-name.up.sql
+timestamp-migration-name.down.sql
+
+# For example, ls into a typical folder should
+# output something like this:
+1552924312928-add-uuid-module.down.sql
+1552924312928-add-uuid-module.up.sql
+1552924312938-create-users-table.down.sql
+1552924312938-create-users-table.up.sql
 ```
 
-*and let the utility do the heavy-lifting!*
+### Environment setup
 
-## Collaboration
-Issues and Pull Requests are welcome! We'll happily discuss them! Don't hesitate to open one if you need a specific feature in your projects.
+Caravel needs to access your database, and so needs information connection: username, password, hostname, port, and database name. You have multiple options to pass these informations to caravel, but the easier is to configure a `DATABASE_URL` into a `.env` file at the root of your project. The other option is to setup a config file in your project and indicate the path of the file each times you’re using caravel. But more on that later.  
+Your `.env` file should look like this.
+
+```dotenv
+# Replace or remove parameters as you nedd.
+DATABASE_URL = postgres://username:password@hostname:port/database_name
+```
+
+## Generating your first migration
+
+Once you went through all this process, you ready to write your first migration! Run `yarn caravel generate create user table`, and watch how caravel generated two files respectively named `[timestamp]-create-user-table.up.sql` and `[timestamp]-create-user-table.down.sql` (`[timestamp]` corresponds the timestamp at when the program has been launched).  
+If you find the files, they reside in the default folder `db/migrations`. The `db` folder is extremely important, because it contains your migrations, but it could also typically contains your schema, your seeds or config files.
+
+Now you should fill your files.
+
+```pgsql
+-- db/migrations/[timestamp]-create-user-table.up.sql
+create extension if not exists "uuid-ossp";
+create table users (
+  id uuid primary key default uuid_generate_v4(),
+  name text
+);
+```
+
+```pgsql
+-- db/migrations/[timestamp]-create-user-table.down.sql
+drop table users;
+drop extension if exists "uuid-ossp";
+```
+
+## Running your migrations
+
+It’s done! You’re ready to run your first migrations. Execute `yarn caravel migrate`, and watch caravel generates the `caravel_migrations` table into the database, taking the `create-user-table.up.sql` and running it against the database!
+
+That’s fine, your database is up to date! Now, every times you need to modify the database, generates a migration with caravel, and run it against the database again!
+
+## Oops, it looks like we made a mistake…
+
+Damn, we made a mistake in the user file! We used `name text` but it’s hard to distinguish between first and last name! Ok, don’t panic, we’ll fix that now.
+
+First we need to rollback our last transaction. Run `yarn caravel down`. Caravel should run `create-user-table.down.sql`. Because you made things right, Postgres should have dropped the `users` table, and the `uuid-ossp` extension. That's fine, we’re in the exact same configuration as before. That’s perfect. It’s like nothing happened. We can do things right now.
+
+Now, we need to change the file.
+
+```pgsql
+--- db/migrations/[timestamp]-create-user-table.up.sql should look like this.
+create extension if not exists "uuip-ossp";
+create table users (
+  id uuid primary key default uuid_generate_v4(),
+  first_name text,
+  last_name text
+);
+```
+
+That looks cool! Now, run `yarn caravel migrate`. And you’re good! The database is now in correct state! You can easily check it with a query (like `select first_name, last_name from users;`).
+
+Now you have everything you need to continue with caravel!
+
+# Detailled usage
+
+Caravel can directly be called thought CLI, or can be programmatically accessed.
+
+## CLI Usage
+
+You have different commands you can use: `migrate`, `revert` and `generate`.
+
+The program can be called with two global options: `--config` with the path to a specific database config file, allowing certain commands to be run against a specific database; and `--folder` with the path to the migrations folder, in case you don’t want to use the default `db/migrations` folder. Keep in mind that the path will always be resolved with a `path.resolve`.
+
+`migrate` should be used without any further arguments and will execute your migrations in order.  
+`revert` should either takes no argument or accept one int arguments, indicating how much migrations should be reverted. Now arguments defaults to one migration to revert.  
+`generate` accepts an arbitrary number of arguments, which should correspond to the filename. It is also possible to use a long string without spaces. Every space will be turned into dash (`-`).
+
+## Programmatic usage
+
+In the same way as the CLI usage, you have access to three commands through the `migrations` object: `migrations.run`, `migrations.revert`, and `migrations.generate`. They’re all asynchronous function returning promises.
+
+`run(configFilePath, migrationsFolder)` is a function accepting the path to the config file, and the path to the custom migrations folder and run the migration against the database.  
+`revert(configFilePath, migrationsFolder, numberToInvert)` is a function accepting the path to the config file, and the path to the custom migrations folder as well as a number of migrations which need to be inverted against the database.  
+`generate(migrationsFolder, name, options)` is a function accepting the path to the custom migrations folder, a filename as string (all spaces will be replaced with dashs (`-`)), and an options object, containing only a `verbose` field for now.
+
+Just require caravel (`const Caravel = require('caravel')`) and you can call `Caravel.migrations.run`, `Caravel.migrations.revert` or `Caravel.migrations.generate` right away.
+
+## Detailled configuration options
+
+- The default migrations folder can be configured through the `MIGRATIONS_FOLDER_NAME` in your `.env` file, or through the `--folder` flag on the CLI.
+
+- The database connection can be configured with a custom config file. The config file should be a JSON or a JavaScript file exposing an object corresponding to a [Node Postgres config object](https://node-postgres.com/api/client).
+
+- In case you don’t want to provide a config file, you can just define a `DATABASE_URL` variable in your `.env` file.
+
+- If you’re using a service like AWS or GCP, you should also define the `DATABASE_URL` directly in the environment variables, and you don’t need to use a `.env` file.
+
+- If you did not defined a `DATABASE_URL`, the client will automatically try to find the correct parameters:
+
+  ```js
+  {
+    user: process.env.PGUSER || process.env.USER,
+    password: process.env.PGPASSWORD,
+    database: process.env.PGDATABASE || process.env.USER,
+    port: process.env.PGPORT,
+    host: process.env.PGHOST,
+  }
+  ```
+
+  More information could be found in the [Node Postgres documentation](https://node-postgres.com/features/connecting#environment-variables).
+
+# How it works
+
+## The algorithms used
+
+Caravel covers three mains use cases: running migrations, reverting migrations, and generating migrations.
+
+### Running migration
+
+Caravel looks through your `migrations` folder for migrations that haven’t already been applied to your database. In order to do this, it will compare your migrations timestamp with the ones stored in the `caravel_migrations` table, and run those that need to be, updating both your project’s database and the migrations table.
+
+You don’t need to bother about `caravel_migrations`. Caravel will create the table if it doesn’t exist. Otherwise it will use it to store the progression.
+
+### Reverting migration
+
+Caravel looks through the database and find the most recent migration. Recent like the last timestamp in the migrations folder, which is not inevitably the last migration made. (In case of merge, for example.) With the most recent migration, it tries to find the corresponding `[timestamp]-filename.down.sql` file, and run it against the database.  
+It is strongly advised to test your down migrations files before pushing them into production.  
+If you asked for more than one migration, caravel will revert them one by one, starting by the most recent to the most older.
+
+### Generating migration
+
+Caravel can generate migrations with proper timestamp, to do the hard work for you. When asking for new migration, caravel will fetch the actual timestamp, and creates two empty files with the timestamp and the words you indicated on the command line, separated by dashs (`-`). You can then replace the content with the code you need.
+
+# Collaboration
+
+Issues and Pull Requests are welcome! We’ll happily discuss them! Don’t hesitate to open one if you need a specific feature in your projects.
 Forking the project is fine for us too!

--- a/bin/index.js
+++ b/bin/index.js
@@ -41,15 +41,15 @@ program
   })
 
 program
-  .command('down [howMuch]')
-  .alias('d')
+  .command('revert [howMuch]')
+  .alias('r')
   .description('Invert the last final(s) migration(s)')
   .action(async options => {
     const result = parseInt(options || 1)
     if (isNaN(result)) {
       console.log('Enter a valid number.')
     } else {
-      await migrations.invert(program.config, program.folder, result)
+      await migrations.revert(program.config, program.folder, result)
     }
   })
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -2,7 +2,7 @@
 
 const program = require('commander')
 
-const main = require('../src/main')
+const migrations = require('../src/migrations')
 const generate = require('../src/generate')
 
 program
@@ -15,7 +15,7 @@ program
   .alias('m')
   .description('Run migration files in migrations folder if necessary')
   .action(async () => {
-    await main.runMigrations(program.config, program.folder)
+    await migrations.run(program.config, program.folder)
   })
 
 program
@@ -24,6 +24,19 @@ program
   .description('Generate correct migration in migrations folder')
   .action(async options => {
     await generate.migration(program.folder, options.join('-'))
+  })
+
+program
+  .command('down [howMuch]')
+  .alias('d')
+  .description('Invert the last final(s) migration(s)')
+  .action(async options => {
+    const result = parseInt(options || 1)
+    if (isNaN(result)) {
+      console.log('Enter a valid number.')
+    } else {
+      await migrations.invert(program.config, program.folder, result)
+    }
   })
 
 if (!process.argv.slice(2).length) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -5,8 +5,22 @@ const program = require('commander')
 const migrations = require('../src/migrations')
 const generate = require('../src/generate')
 
+const helpText = [
+  'Caravel helps dealing with PostgreSQL database migration. It focuses around',
+  'three main features: migration managing with up and down, and generating',
+  'migration up and down files.',
+  '',
+  'Caravel is extremely easy to use, because it simply uses bare, simple SQL.',
+  'Caravel deals exclusively with SQL files, written in pure SQL, in a migration',
+  'folder. By using caravel generate, you can generate [timestamp]-filename.up.sql',
+  'and [timestamp]-filename.down.sql. These files need to be filled with your queries',
+  'like \'CREATE TABLE users (fields);\' and \'DROP TABLE users;\', and then run',
+  'caravel migrate to get everyting up and running!'
+].join('\n')
+
 program
-  .version('0.1.0')
+  .version('0.1.2')
+  .description(helpText)
   .option('-c, --config <path>', 'Specify connection database config file')
   .option('-f, --folder <path>', 'Specify migrations folder path')
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+require('dotenv').config()
+
 const program = require('commander')
 
 const migrations = require('../src/migrations')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wolfox/caravel",
   "version": "0.1.1",
-  "main": "src/main.js",
+  "main": "src/entrypoint.js",
   "description": "Smart, simple and efficient way to manage PostgreSQL migration files.",
   "repository": "git@github.com:wolfoxco/caravel.git",
   "homepage": "https://github.com/wofoxco/caravel",

--- a/src/client.js
+++ b/src/client.js
@@ -1,10 +1,10 @@
+require('dotenv').config()
+
 const helpers = require('./helpers')
 const path = require('path')
 const { Client } = require('pg')
-const dotenv = require('dotenv')
 
 const createClientFromEnv = () => {
-  dotenv.config()
   const { DATABASE_URL } = process.env
   if (DATABASE_URL) {
     return new Client({

--- a/src/client.js
+++ b/src/client.js
@@ -4,6 +4,7 @@ const { Client } = require('pg')
 const dotenv = require('dotenv')
 
 const createClientFromEnv = () => {
+  dotenv.config()
   const { DATABASE_URL } = process.env
   if (DATABASE_URL) {
     return new Client({
@@ -24,30 +25,10 @@ const createClientFromConfigFile = configFilePath => {
   }
 }
 
-const createClientFromNakedEnv = () => {
-  const nakedClient = createClientFromEnv()
-  if (nakedClient) {
-    return nakedClient
-  } else {
-    return null
-  }
-}
-
-const createClientFromDotenvEnv = () => {
-  dotenv.config()
-  const dotEnvClient = createClientFromEnv()
-  if (dotEnvClient) {
-    return dotEnvClient
-  } else {
-    return null
-  }
-}
-
 const create = configFilePath => {
   return (
     createClientFromConfigFile(configFilePath)
-    || createClientFromNakedEnv()
-    || createClientFromDotenvEnv()
+    || createClientFromEnv()
     || new Client()
   )
 }

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -1,0 +1,12 @@
+const { run, revert } = require('./migrations')
+const generate = require('./generate')
+
+const migrations = {
+  run,
+  revert,
+  generate: generate.migration,
+}
+
+module.exports = {
+  migrations
+}

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const path = require('path')
 const fs = require('fs')
 const chalk = require('chalk')

--- a/src/generate.js
+++ b/src/generate.js
@@ -47,10 +47,12 @@ const migration = (migrationsFolder, name, options = { verbose: true }) => {
   if (name.length === 0) {
     if (options.verbose) {
       console.error(chalk.bold.red('You did not specified migration name. Aborting.'))
+      return false
     }
+    return false
   } else {
     const migrationsPath = path.resolve(migrationsFolder || MIGRATIONS_FOLDER)
-    return createMigrationsFolderAndFiles(migrationsPath, name, options)
+    return createMigrationsFolderAndFiles(migrationsPath, name.replace(' ', '-'), options)
   }
 }
 

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const path = require('path')
 const chalk = require('chalk')
 const helpers = require('./helpers')

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -158,15 +158,19 @@ const run = (configFilePath, migrationsFolder) => {
 }
 
 const revert = (configFilePath, migrationsFolder, numberToInvert) => {
-  const applier = (migrationsRowsFromDB, upAndDownMigrationsFromFS) => {
-    if (migrationsRowsFromDB.length === 0) {
-      return Promise.reject('You don’t have any migration made.')
-    } else {
-      const migrationsRows = migrationsRowsFromDB.reverse()
-      return revertOneByOne(numberToInvert, migrationsRows, upAndDownMigrationsFromFS[1])
+  if (process.env.NODE_ENV !== 'production') {
+    const applier = (migrationsRowsFromDB, upAndDownMigrationsFromFS) => {
+      if (migrationsRowsFromDB.length === 0) {
+        return Promise.reject('You don’t have any migration made.')
+      } else {
+        const migrationsRows = migrationsRowsFromDB.reverse()
+        return revertOneByOne(numberToInvert, migrationsRows, upAndDownMigrationsFromFS[1])
+      }
     }
+    return connectAndSetupEnvironment(configFilePath, migrationsFolder, applier)
+  } else {
+    return false
   }
-  return connectAndSetupEnvironment(configFilePath, migrationsFolder, applier)
 }
 
 module.exports = {

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,0 +1,34 @@
+const createMigrationsTable = (client, tableName) => {
+  return client.query(
+    `CREATE TABLE ${tableName} (version text PRIMARY KEY)`
+  )
+}
+
+const checkIfMigrationTableExists = async (client, tableName) => {
+  const response = await client.query(`
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_name = '${tableName}'
+    )`
+  )
+  const { exists } = response.rows[0]
+  if (!exists) {
+    console.log('🔧 No migration table found, creating...')
+    await createMigrationsTable(client, tableName)
+    console.log('👌 Migrations table created')
+  } else {
+    console.log('👌 Migration table exists')
+  }
+}
+
+const getAllMigrationsFromTable = async (client, tableName) => {
+  console.log('📈 Getting all migrations in table...')
+  const response = await client.query(`SELECT * FROM ${tableName} ORDER BY version`)
+  return response.rows
+}
+
+module.exports = {
+  checkIfMigrationTableExists,
+  getAllMigrationsFromTable,
+}


### PR DESCRIPTION
# Automating is still key

We have migrations, we can run them, but we cannot invert them. We can now do it as simply as `yarn caravel down`. This would greatly improve things when developing.

# Other things

We now have a README with all the useful informations. We have description with help when running caravel onto the command line.

There was a small global refactoring.